### PR TITLE
Option --authors to 'kw maintainers'

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,13 @@ kw codestyle <DIRECTORY_PATH | FILE_PATH>
 ```
 
 > Get maintainers (directory or file):
-
+> The option [-a|--authors] will print the file author of FILE_PATH or
+> the authors of the files under DIRECTORY_PATH (non-recursively). Files
+> with more than one author will have their authors separated by ",".
+> Use with care, because sometimes, authors include also "," in their
+> names (e.g. "Company X, Inc.").
 ```
-kw maintainers <DIRECTORY_PATH | FILE_PATH>
+kw maintainers [-a|--authors] <DIRECTORY_PATH | FILE_PATH>
 ```
 
 > You can put your VM in a status that is ready for work with the prepare

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -1,8 +1,56 @@
 . $src_script_path/miscellaneous.sh --source-only
 
+
+function print_files_authors()
+{
+    # TODO: currently only authors found in a single line MODULE_AUTHOR
+    # statement are captured and printed. In the future, it would be
+    # nice to look for multiline MODULE_AUTHOR statatements such as:
+    #
+    # MODULE_AUTHOR ("a_long_email@xx.com" \
+    #                "another_long@yy.com" )
+    # and:
+    #
+    # MODULE_AUTHOR ("a_long_email@xx.com"
+    #                "another_long@yy.com" )
+    #
+    # which are, both, valid C statements. In the currently
+    # implementation neither of these four emails will be printed.
+
+    local FILE_OR_DIR=$1
+    local files=( )
+    if [[ -d $FILE_OR_DIR ]]; then
+        for file in $FILE_OR_DIR/*; do
+            if [[ -f $file ]]; then
+                files+=($file)
+            fi
+        done
+    elif [[ -f $FILE_OR_DIR ]]; then
+        files+=($FILE_OR_DIR)
+    fi
+
+    local printed_authors_separator=false
+
+    for file in ${files[@]}; do
+        authors=$(grep -oE "MODULE_AUTHOR *\(.*\)" $file |
+                  sed -E "s/(MODULE_AUTHOR *\( *\"|\" *\))//g" |
+                  sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/, /g' )
+        if [[ ! -z $authors ]]; then
+            if [ $printed_authors_separator = false ]; then
+                say $SEPARATOR
+                say "MODULE AUTHORS:"
+                printed_authors_separator=true
+            fi
+            say -n "$(basename $file): "
+            echo "$authors"
+        fi
+    done
+}
+
 function execute_get_maintainer()
 {
-  local FILE_OR_DIR_CHECK=$1
+  local FILE_OR_DIR_CHECK
+  local print_authors
 
   local -r script="scripts/get_maintainer.pl"
   local -r options="--separator , --nokeywords --nogit --nogit-fallback --norolestats "
@@ -14,6 +62,14 @@ function execute_get_maintainer()
     return
   fi
 
+  if [[ $# -ge 1 && ( $1  = "--authors" || $1 = "-a" ) ]]; then
+      FILE_OR_DIR_CHECK=$2
+      print_authors=true
+  else
+      FILE_OR_DIR_CHECK=$1
+      print_authors=false
+  fi
+
   # Check if is a valid path
   if [ ! -d $FILE_OR_DIR_CHECK -a ! -f $FILE_OR_DIR_CHECK ]; then
     complain "Invalid path"
@@ -23,4 +79,8 @@ function execute_get_maintainer()
   say $SEPARATOR
   say "HERE:"
   $getmaintainers $FILE_OR_DIR_CHECK
+
+  if [ $print_authors = true ]; then
+      print_files_authors $FILE_OR_DIR_CHECK
+  fi
 }

--- a/src/miscellaneous.sh
+++ b/src/miscellaneous.sh
@@ -1,20 +1,34 @@
-declare -r BLUECOLOR="\033[1;34;49m%s\033[m\n"
-declare -r REDCOLOR="\033[1;31;49m%s\033[m\n"
-declare -r YELLOWCOLOR="\033[1;33;49m%s\033[m\n"
-declare -r GREENCOLOR="\033[1;32;49m%s\033[m\n"
+declare -r BLUECOLOR="\033[1;34;49m%s\033[m"
+declare -r REDCOLOR="\033[1;31;49m%s\033[m"
+declare -r YELLOWCOLOR="\033[1;33;49m%s\033[m"
+declare -r GREENCOLOR="\033[1;32;49m%s\033[m"
 declare -r SEPARATOR="========================================================="
 
 # Print colored message. This function verifies if stdout
 # is open and print it with color, otherwise print it without color.
-# @param $1 ${@:2} it receives the variable defining the color
-# to be used and text message to be printed.
+#
+# @param $1 [${@:2}] [-n ${@:3}] it receives the variable defining
+# the color to be used and two optional params:
+#   - the option '-n', to not output the trailing newline
+#   - text message to be printed
+#
 function colored_print()
 {
-    message="${@:2}"
-    if [ -t 1 ]; then
-      printf ${!1} "$message"
+    local message="${@:2}"
+
+    if [[ $# -ge 2 && $2 = "-n" ]]; then
+        message="${@:3}"
+        if [ -t 1 ]; then
+            printf ${!1} "$message"
+        else
+            echo -n "$message"
+        fi
     else
-      echo "$message"
+        if [ -t 1 ]; then
+            printf "${!1}\n" "$message"
+        else
+            echo "$message"
+        fi
     fi
 }
 

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -19,6 +19,8 @@ function kworkflow-help()
     "\tvars - Show variables\n" \
     "\tup,u - Wake up vm\n" \
     "\tcodestyle - Apply checkpatch on directory or file\n" \
-    "\tmaintainers - Return the maintainers and the mailing list\n" \
-    "\thelp"
+    "\tmaintainers [-a|--authors] - Return the maintainers and\n" \
+    "\t                             the mailing list. \"-a\" also\n" \
+    "\t                             prints files authors\n" \
+    "\thelp - displays this help mesage"
 }

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+. ./src/get_maintainer_wrapper.sh --source-only
+. ./tests/utils --source-only
+
+# TODO: unit test for execute_get_maintainer
+
+function suite
+{
+  suite_addTest "testPrintFileAuthorForFile"
+  suite_addTest "testPrintFileAuthorForDir"
+}
+
+# Hold the the lines print_files_authors should print when given the file
+# samples/print_file_author_test_dir directory and
+# samples/print_file_author_test_dir/code1.c file, respectively
+CORRECT_DIR_MSG=(
+    "========================================================="
+    "MODULE AUTHORS:"
+    "code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
+    "code2.c: Bob Hilson <bob@opensource.com>"
+)
+CORRECT_FILE_MSG=(
+    "========================================================="
+    "MODULE AUTHORS:"
+    "code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
+)
+
+function testPrintFileAuthorForFile
+{
+  local counter=0
+  while read -r line
+  do
+    local expected=${CORRECT_FILE_MSG[$counter]}
+    if [[ "$line" != "$expected" ]]; then
+        fail "Expecting line $counter to be:\n\"$expected\"\nBut got:\n\"$line\""
+        true # Reset return value
+        return
+    fi
+    ((counter+=1))
+  done < <(print_files_authors "tests/samples/print_file_author_test_dir/code1.c")
+  true # Reset return value
+}
+
+function testPrintFileAuthorForDir
+{
+    local counter=0
+    while read -r line
+    do
+      local expected=${CORRECT_DIR_MSG[$counter]}
+      if [[ "$line" != "$expected" ]]; then
+          fail "Expecting line $counter to be:\n\"$expected\"\nBut got:\n\"$line\""
+          true # Reset return value
+          return
+      fi
+      ((counter+=1))
+    done < <(print_files_authors "tests/samples/print_file_author_test_dir")
+    true # Reset return value
+}
+
+
+invoke_shunit

--- a/tests/samples/print_file_author_test_dir/code1.c
+++ b/tests/samples/print_file_author_test_dir/code1.c
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * codestyle.c
+ *
+ * Copyright (C) 2018 John Doe
+ *
+ * This file is used to test the print_files_authors function
+ * at src/get_maintainer_wrapper.sh.
+ *
+ */
+
+#include <stdio.h>
+
+void ordinary_function(void)
+{
+	puts("Just a function...");
+}
+
+int main(int argc, char *args[])
+{
+	int i;
+	printf("%d\n", argc);
+	for (i = 0; i < argc; ++i)
+		printf("%s ", args[i]);
+	return 0;
+}
+
+MODULE_AUTHOR ( "John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>" )
+ORDINARY_MACRO ("Does something..."); MODULE_AUTHOR("Michael Doe <michael@community.com>")

--- a/tests/samples/print_file_author_test_dir/code2.c
+++ b/tests/samples/print_file_author_test_dir/code2.c
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * codestyle.c
+ *
+ * Copyright (C) 2018 Bob Hilson
+ *
+ * This file is used to test the print_files_authors function
+ * at src/get_maintainer_wrapper.sh.
+ *
+ */
+
+#include <stdio.h>
+
+void ordinary_function2(void)
+{
+	puts("Just a function...");
+}
+
+int main(int argc, char *args[])
+{
+	int i;
+	printf("%d\n", argc);
+	for (i = 0; i < argc; ++i)
+		printf("%s ", args[i]);
+	return 0;
+}
+
+MODULE_AUTHOR ( "Bob Hilson <bob@opensource.com>" )


### PR DESCRIPTION
This PR adds an option 'kw maintainers [-a|--authors]' which, when used, prints the module's authors of the given file. If the given file is a directory, it prints the authors for each file in the given dir.