### PR TITLE
Fix run_tests.sh's test failure check

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -101,15 +101,15 @@ function report_results
     elif [[ $success -eq $total ]]; then
       success $SEPARATOR
       success "Total: $total test file(s)"
-      success "Test(s) SUCCEEDED"
+      success "Test file(s) SUCCEEDED"
     else
       complain $SEPARATOR
       complain "Total: $total test file(s)"
       if [[ $fail -gt 0 ]]; then
-        complain "$fail test(s) FAILED"
+        complain "$fail test file(s) FAILED"
       fi
       if [[ $notfound -gt 0 ]]; then
-        complain "$notfound test(s) NOT FOUND"
+        complain "$notfound test file(s) NOT FOUND"
       fi
     fi
 }
@@ -129,10 +129,10 @@ function run_tests
         init_env
         ./tests/${current_test}.sh
         )
-        if [[ "$?" -eq 1 ]]; then
-            fail+=1
-        else
+        if [[ "$?" -eq 0 ]]; then
             success+=1
+        else
+            fail+=1
         fi
     else
         complain "Test file ./tests/${current_test}.sh not found."


### PR DESCRIPTION
Previously run_tests.sh categorized the test files that returned 1 as
failures and all others as success. This made, for example, test files
without execution permission to be considered as successfully 
executed. Now, only the ones that returns 0 are considered success
and all others are considered failures.

Also, the function report_results was printing the number of test
files that succeeded, failed and wasn't found, not the number of
tests. So the strings to be printed were changed from "tests" to "test
files".