### PR TITLE
Make 'kw maintainers' work from any directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/shunit2
 .checkpatch-camelcase.date.*
 tests/external
 tests/.tmp_commons_test
+tests/.tmp

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -38,12 +38,14 @@ function get_external_scripts()
   local ret
 
   local -r CHECKPATCH_URL="https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl"
+  local -r MAINTAINER_URL="https://raw.githubusercontent.com/torvalds/linux/master/scripts/get_maintainer.pl"
   local -r CHECKPATCH_CONST_STRUCTS="https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch"
   local -r CHECKPATCH_SPELLING="https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt"
   local DOWNLOAD_URLS=( \
         CHECKPATCH_URL \
         CHECKPATCH_CONST_STRUCTS \
-        CHECKPATCH_SPELLING )
+        CHECKPATCH_SPELLING \
+        MAINTAINER_URL )
 
   say "Downloading external scripts..."
   echo
@@ -72,7 +74,8 @@ function check_required_files()
   if [[ "$force_update" = false &&
            -f "$PATH_TO_TESTS_EXTERNALS/checkpatch.pl" &&
            -f "$PATH_TO_TESTS_EXTERNALS/const_structs.checkpatch" &&
-           -f "$PATH_TO_TESTS_EXTERNALS/spelling.txt" ]] ; then
+           -f "$PATH_TO_TESTS_EXTERNALS/spelling.txt" &&
+           -f "$PATH_TO_TESTS_EXTERNALS/get_maintainer.pl" ]] ; then
        # Errno code for File exist
        return 17
   else

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -11,52 +11,37 @@ function suite
   suite_addTest "testPrintFileAuthorForDir"
 }
 
-# Hold the the lines print_files_authors should print when given the file
-# samples/print_file_author_test_dir directory and
-# samples/print_file_author_test_dir/code1.c file, respectively
-CORRECT_DIR_MSG=(
-    "========================================================="
-    "MODULE AUTHORS:"
-    "code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
-    "code2.c: Bob Hilson <bob@opensource.com>"
-)
-CORRECT_FILE_MSG=(
-    "========================================================="
-    "MODULE AUTHORS:"
-    "code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
-)
+# The following variables hold the the lines print_files_authors should
+# print when given the file samples/print_file_author_test_dir directory
+# and samples/print_file_author_test_dir/code1.c file, respectively.
+CORRECT_DIR_MSG="=========================================================
+MODULE AUTHORS:
+code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>
+code2.c: Bob Hilson <bob@opensource.com>"
+CORRECT_FILE_MSG="=========================================================
+MODULE AUTHORS:
+code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
 
 function testPrintFileAuthorForFile
 {
-  local counter=0
-  while read -r line
-  do
-    local expected=${CORRECT_FILE_MSG[$counter]}
-    if [[ "$line" != "$expected" ]]; then
-        fail "Expecting line $counter to be:\n\"$expected\"\nBut got:\n\"$line\""
-        true # Reset return value
-        return
-    fi
-    ((counter+=1))
-  done < <(print_files_authors "tests/samples/print_file_author_test_dir/code1.c")
+  local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir/code1.c")
+  if [[ "$ret" != "$CORRECT_FILE_MSG" ]]; then
+    local -r expected_prefixed=$(prefix_multiline "$CORRECT_FILE_MSG")
+    local -r got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_prefixed\nBut got:\n$got_prefixed"
+  fi
   true # Reset return value
 }
 
 function testPrintFileAuthorForDir
 {
-    local counter=0
-    while read -r line
-    do
-      local expected=${CORRECT_DIR_MSG[$counter]}
-      if [[ "$line" != "$expected" ]]; then
-          fail "Expecting line $counter to be:\n\"$expected\"\nBut got:\n\"$line\""
-          true # Reset return value
-          return
-      fi
-      ((counter+=1))
-    done < <(print_files_authors "tests/samples/print_file_author_test_dir")
-    true # Reset return value
+  local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir")
+  if [[ "$ret" != "$CORRECT_DIR_MSG" ]]; then
+    local -r expected_prefixed=$(prefix_multiline "$CORRECT_DIR_MSG")
+    local -r got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_prefixed\nBut got:\n$got_prefixed"
+  fi
+  true # Reset return value
 }
-
 
 invoke_shunit

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -3,12 +3,14 @@
 . ./src/get_maintainer_wrapper.sh --source-only
 . ./tests/utils --source-only
 
-# TODO: unit test for execute_get_maintainer
+# TODO: make execute_get_maintainer's tests cover more corner cases?
 
 function suite
 {
   suite_addTest "testPrintFileAuthorForFile"
   suite_addTest "testPrintFileAuthorForDir"
+  suite_addTest "testLinuxRootCheck"
+  suite_addTest "testGetMaintainers"
 }
 
 # The following variables hold the the lines print_files_authors should
@@ -21,6 +23,50 @@ code2.c: Bob Hilson <bob@opensource.com>"
 CORRECT_FILE_MSG="=========================================================
 MODULE AUTHORS:
 code1.c: John Doe <johndoe@community.com>, Caesar Doe <caesar@community.com>, Michael Doe <michael@community.com>"
+
+# The following variables hold the the lines execute_get_maintainer
+# should print when given the path tests/.tmp and tests/.tmp/fs,
+# respectively.
+CORRECT_TMP_MSG="=========================================================
+HERE:
+Jane Doe <jane@email.com>,kernel@list.org"
+CORRECT_TMP_FS_MSG="=========================================================
+HERE:
+John Doe <john@email.com>,Jane Doe <jane@email.com>,fs@list.org,kernel@list.org"
+
+function setupGetMaintainers
+{
+  # This creates tests/.tmp which should mock a kernel tree root. A .git
+  # dir is also created inside tests/.tmp so that get_maintainer.pl thinks
+  # it is a git repo. This is done in order to avoid some warnings that
+  # get_maintainer.pl prints when no .git is found.
+  mkdir -p "tests/.tmp"
+  cd "tests/.tmp"
+  touch "COPYING"
+  touch "CREDITS"
+  touch "Kbuild"
+  touch "Makefile"
+  touch "README"
+  mkdir -p "Documentation"
+  mkdir -p "arch"
+  mkdir -p "include"
+  mkdir -p "drivers"
+  mkdir -p "fs"
+  mkdir -p "init"
+  mkdir -p "ipc"
+  mkdir -p "kernel"
+  mkdir -p "lib"
+  mkdir -p "scripts"
+  mkdir -p ".git"
+  cd ../../
+  cp -f tests/samples/MAINTAINERS tests/.tmp/MAINTAINERS
+  cp -f tests/external/get_maintainer.pl tests/.tmp/scripts/
+}
+
+function tearDownGetMainteiners
+{
+  rm -rf "tests/.tmp"
+}
 
 function testPrintFileAuthorForFile
 {
@@ -42,6 +88,60 @@ function testPrintFileAuthorForDir
     fail "Expecting return:\n$expected_prefixed\nBut got:\n$got_prefixed"
   fi
   true # Reset return value
+}
+
+function testLinuxRootCheck
+{
+  setupGetMaintainers
+  is_kernel_root "tests/.tmp"
+  [[ "$?" != 0 ]] && fail "Failed to check if a directory is a kernel root."
+  tearDownGetMainteiners
+  true # Reset return value
+}
+
+function testGetMaintainers
+{
+  local ret
+  local got_prefixed
+  local -r expected_tmp_prefixed=$(prefix_multiline "$CORRECT_TMP_MSG")
+  local -r expected_tmp_fs_prefixed=$(prefix_multiline "$CORRECT_TMP_FS_MSG")
+
+  setupGetMaintainers
+
+  ret="$(execute_get_maintainer tests/.tmp)"
+  if [[ "$ret" != "$CORRECT_TMP_MSG" ]]; then
+    got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_tmp_prefixed\nBut got:\n$got_prefixed\n(Calling lkr from outside lkr)"
+  fi
+
+  cd tests/.tmp
+  ret="$(execute_get_maintainer .)"
+  if [[ "$ret" != "$CORRECT_TMP_MSG" ]]; then
+    got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_tmp_prefixed\nBut got:\n$got_prefixed\n(Calling lkr from lkr)"
+  fi
+
+  ret="$(execute_get_maintainer fs)"
+  if [[ "$ret" != "$CORRECT_TMP_FS_MSG" ]]; then
+    got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_tmp_fs_prefixed\nBut got:\n$got_prefixed\n(Calling lkr/fs from lkr)"
+  fi
+
+  cd fs
+  ret="$(execute_get_maintainer ..)"
+  if [[ "$ret" != "$CORRECT_TMP_MSG" ]]; then
+    got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_tmp_prefixed\nBut got:\n$got_prefixed\n(Calling lkr from lkr/fs)"
+  fi
+
+  ret="$(execute_get_maintainer .)"
+  if [[ "$ret" != "$CORRECT_TMP_FS_MSG" ]]; then
+    got_prefixed=$(prefix_multiline "$ret")
+    fail "Expecting return:\n$expected_tmp_fs_prefixed\nBut got:\n$got_prefixed\n(Calling lkr/fs from lkr/fs)"
+  fi
+  cd ../../../
+
+  tearDownGetMainteiners
 }
 
 invoke_shunit

--- a/tests/samples/MAINTAINERS
+++ b/tests/samples/MAINTAINERS
@@ -1,0 +1,13 @@
+# This is a sample MAINTAINERS file. It is used by the
+# get_maintainer_wrapper_test.sh
+
+FILESYSTEMS
+M:	John Doe <john@email.com>
+L:	fs@list.org
+F:	fs/*
+
+THE REST
+M:	Jane Doe <jane@email.com>
+L:	kernel@list.org
+F:	*
+F:	*/

--- a/tests/utils
+++ b/tests/utils
@@ -8,6 +8,13 @@ function init_env
   export src_script_path external_script_path EASY_KERNEL_WORKFLOW
 }
 
+# Receives a string with one or more lines and print each of
+# then prefixed by "> "
+function prefix_multiline
+{
+  echo "$@" | sed -E "s/^/> /g"
+}
+
 function invoke_shunit
 {
   command -v shunit2 > /dev/null


### PR DESCRIPTION
This PR makes  'kw maintainers' work  from any directory. It fixes #28 

It does that looking for he kernel tree root, cd-ing to it before running get_maintainers and cd-ing back after.