### PR TITLE
Replaces hardcoded variables with default config

### DIFF
--- a/kworkflow.config.example
+++ b/kworkflow.config.example
@@ -1,3 +1,17 @@
+base=$HOME/p/linux-trees
+mount_point=$HOME/p/mount
+build_dir=$base/build-linux
+
+qemu_arch=x86_64
+qemu=qemu-system-${qemu_arch}
+qemu_mnt=/mnt/qemu
+
+port=2222
+ip=127.0.0.1
+
+target=qemu
+bashpath=/bin/bash
+
 qemu_hw_options=-enable-kvm -daemonize -m 3G -smp cores=4,cpus=4
-qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=$HOME 
+qemu_net_options=-net nic -net user,hostfwd=tcp::$port-:22,smb=$HOME
 qemu_path_image=$HOME/p/virty.qcow2

--- a/setup.sh
+++ b/setup.sh
@@ -42,6 +42,7 @@ function synchronize_files()
 
   # Copy the script
   cp $APPLICATIONNAME.sh $INSTALLTO
+  cp kworkflow.config.example $INSTALLTO
   rsync -vr $SRCDIR $INSTALLTO
   rsync -vr $DEPLOY_DIR $INSTALLTO
 


### PR DESCRIPTION
Previously kw used global variables in src/commons.sh to store relevant
information. This patch replaces hardcoded variables with their
equivalents in a default configuration file at $HOME/.config/kw/.
Furthermore, variable expansion is supported, allowing for custom
variables to be set in the config files.

Signed-off-by: Renato Lui Geh <renatogeh@gmail.com>
Signed-off-by: Marcelo Schmitt <marcelo.schmitt1@gmail.com>