### PR TITLE
Rework the config file manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ kw help
 pull from this repository and install again (`./setup -i` remove legacy files
 and intall new one).
 
+# Global configuration file
+
+> All the default configurations used by kworflow can be seen at
+"~/.config/kw/etc/kworkflow.config"; this config file has a comment on each
+configuration option. Finally, it is important to highlight that kw loads de
+default configurations; next, it tries to find a local configuration file
+(detailed ahead) and overwrite the global option by the ones read from the
+local config file.
+
 # Local configuration file
 
 > One of the features of this project, it is the ability to set a specific set

--- a/etc/kworkflow.config
+++ b/etc/kworkflow.config
@@ -1,0 +1,29 @@
+# Default configuration file
+# Attention: the string USERKW will be replaced by the current user name if you
+# use "./setup.sh". You can manually change this behavior.
+
+# Default ssh ip
+ssh_ip=localhost
+
+# Default ssh port
+ssh_port=2222
+
+# Specify the default architecture used by KW
+arch=x86_64
+
+# Defines the virtualization tool that should be used by kw. Current, we only
+# support QEMU
+virtualizer=qemu-system-x86_64
+
+# Defines the kw mount point, this directory is used by libguestfs during the
+# mount/umount operation of a VM
+mount_point=/home/USERKW/p/mount
+
+# Sets basic QEMU options
+qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
+
+# Defines the network configuration
+qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+
+# Specify the VM image path
+qemu_path_image=/home/USERKW/p/virty.qcow2

--- a/kw.sh
+++ b/kw.sh
@@ -4,6 +4,7 @@
 EASY_KERNEL_WORKFLOW=${EASY_KERNEL_WORKFLOW:-"kw"}
 src_script_path=${src_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/src"}
 external_script_path=${external_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/external"}
+config_files_path=${config_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/etc"}
 
 # Export external variables required by kworkflow
 export EASY_KERNEL_WORKFLOW

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ declare -r APPLICATIONNAME_1="vm"
 declare -r APPLICATIONNAME_2="mk"
 declare -r SRCDIR="src"
 declare -r DEPLOY_DIR="deploy_rules"
+declare -r CONFIG_DIR="etc"
 declare -r INSTALLTO="$HOME/.config/$APPLICATIONNAME"
 
 declare -r EXTERNAL_SCRIPTS="external"
@@ -33,6 +34,13 @@ function clean_legacy()
   eval "sed -i '/$toDelete/d' $HOME/.bashrc"
 }
 
+function setup_config_file()
+{
+  say "Customizing configurations"
+  local match_rule="s/USERKW/$USER/g"
+  sed -i $match_rule $INSTALLTO/$CONFIG_DIR/*.config
+}
+
 # Synchronize .vim and .vimrc with repository.
 function synchronize_files()
 {
@@ -44,6 +52,10 @@ function synchronize_files()
   cp $APPLICATIONNAME.sh $INSTALLTO
   rsync -vr $SRCDIR $INSTALLTO
   rsync -vr $DEPLOY_DIR $INSTALLTO
+
+  # Configuration
+  rsync -vr $CONFIG_DIR $INSTALLTO
+  setup_config_file
 
   # Add to bashrc
   echo "# $APPLICATIONNAME" >> $HOME/.bashrc

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -2,13 +2,11 @@
 
 function vm_modules_install
 {
-  check_local_configuration
-
   # Attention: The vm code have to be loaded before this function.
   # Take a look at the beginning of kworkflow.sh.
   vm_mount
   set +e
-  make INSTALL_MOD_PATH=$MOUNT_POINT modules_install
+  make INSTALL_MOD_PATH=${configurations[mount_point]} modules_install
   release=$(make kernelrelease)
   say $release
   vm_umount
@@ -16,11 +14,9 @@ function vm_modules_install
 
 function vm_kernel_install
 {
-  check_local_configuration
-
   vm_mount
   set +e
-  sudo -E make INSTALL_PATH=$QEMU_MNT/boot
+  sudo -E make INSTALL_PATH=${configurations[mount_point]}/boot
   release=$(make kernelrelease)
   vm_umount
 }
@@ -49,8 +45,6 @@ function mk_build
 
 function mk_install
 {
-  check_local_configuration
-
   # FIXME: validate arch and action
   if [ $TARGET == "arm" ] ; then
     export ARCH=arm CROSS_COMPILE="ccache arm-linux-gnu-"
@@ -101,8 +95,6 @@ function mk_send_mail
 # FIXME: Here we have a legacy code, check if we can remove it
 function mk_export_kbuild
 {
-  check_local_configuration
-
   say "export KBUILD_OUTPUT=$BUILD_DIR/$TARGET"
   export KBUILD_OUTPUT=$BUILD_DIR/$TARGET
   mkdir -p $KBUILD_OUTPUT

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -2,35 +2,36 @@
 
 function vm_mount
 {
-  check_local_configuration
+  mkdir -p ${configurations[mount_point]}
 
-  mkdir -p $MOUNT_POINT
-  say "Mount $VDISK in $MOUNT_POINT"
-  guestmount -a $VDISK -i $MOUNT_POINT
+  say "Mount ${configurations[qemu_path_image]}" \
+      "in ${configurations[mount_point]}"
+
+  guestmount -a ${configurations[qemu_path_image]} \
+             -i ${configurations[mount_point]}
+
   if [ "$?" != 0 ] ; then
-    complain "Something went wrong when tried to mount $VDISK in $MOUNT_POINT"
+    complain "Something went wrong when tried to mount" \
+        "${configurations[qemu_path_image]} in ${configurations[mount_point]}"
     return 1
   fi
 }
 
 function vm_umount
 {
-  check_local_configuration
-
-  say "Unmount $MOUNT_POINT"
-  guestunmount $MOUNT_POINT
+  say "Unmount ${configurations[mount_point]}"
+  guestunmount ${configurations[mount_point]}
   if [ "$?" != 0 ] ; then
-    complain "Something went wrong when tried to unmount $VDISK in $MOUNT_POINT"
+    complain "Something went wrong when tried to unmount" \
+        "${configurations[qemu_path_image]} in ${configurations[mount_point]}"
     return 1
   fi
 }
 
 function vm_boot
 {
-  check_local_configuration
-
-  $QEMU -hda $VDISK \
-    ${QEMU_OPTS} \
+  ${configurations[virtualizer]} -hda ${configurations[qemu_path_image]} \
+    ${configurations[qemu_hw_options]} \
     -kernel $BUILD_DIR/$TARGET/arch/x86/boot/bzImage \
     -append "root=/dev/sda1 debug console=ttyS0 console=ttyS1 console=tty1" \
     -net nic -net user,hostfwd=tcp::5555-:22 \
@@ -40,25 +41,21 @@ function vm_boot
 
 function vm_up
 {
-
-  check_local_configuration
-
   say "Starting Qemu with: "
-  echo "$QEMU ${configurations[qemu_hw_options]}" \
+  echo "${configurations[virtualizer]} ${configurations[qemu_hw_options]}" \
        "${configurations[qemu_net_options]}" \
        "${configurations[qemu_path_image]}"
 
-  $QEMU ${configurations[qemu_hw_options]} \
+  ${configurations[virtualizer]} ${configurations[qemu_hw_options]} \
         ${configurations[qemu_net_options]} \
         ${configurations[qemu_path_image]}
 }
 
 function vm_ssh
 {
-  check_local_configuration
-
-  say "SSH to: port: " ${configurations[port]} " ip: " ${configurations[ip]}
-  ssh -p ${configurations[port]} ${configurations[ip]}
+  say "SSH"
+  say "-> Port: " ${configurations[ssh_port]} " IP: " ${configurations[ssh_ip]}
+  ssh -p ${configurations[ssh_port]} ${configurations[ssh_ip]}
 }
 
 function vm_prepare

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -1,3 +1,6 @@
-key1=value1
-key2=value2
-key3=value3
+ssh_ip=127.0.0.1
+ssh_port=3333
+arch=arm
+virtualizer=libvirt
+mount_point=/home/lala
+qemu_path_image=/home/xpto/p/virty.qcow2


### PR DESCRIPTION
Kworkflow has a messed mechanism for handling global and local variable.
Additionally, there are too many global variables that make things
complicated. This patch uses a single place to store all the global
variables in the same fashion of Unix systems; under
“$HOME/.config/kw/” it is added the directory “etc/” with a global
“kworkflow.config”. Finally, this patch also takes care of the local
config file.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>