### PR TITLE
Add run_tests execution dir restriction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,6 @@ run_tests.sh prepare
 ```
 run_tests.sh prepare -f|--force-update
 ```
+
+> Please note that run_tests.sh must be run from the directory it is in, i.e.
+the root of the repository. Otherwise, it may not execute properly.


### PR DESCRIPTION
A very simple PR to add this info about run_tests to README: it must only be run from the repository's root.

Closes  #46