### PR TITLE
configm: Add '.config' manager with save and list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ following dependencies:
 * Qemu
 * Ansible
 * Bash
+* git
 
 > If you want to use the default alert system (for commands that may take longer
 to run), you will also need to install:
@@ -207,6 +208,25 @@ kw prepare --alert=vs
 
 > The default option, when --alert= is not given is n. It can be configured at
 > the kworflow.config file.
+
+```
+kw configm
+```
+
+> The 'configm' option represents the main application that manages the
+> '.config' files for users. In summary, it provides operations for save, load,
+> removes, and list '.config' files previously saved by the user. See the
+> current options:
+
+- `--save NAME [-d DESCRIPTION] [-f]` The save option seeks in the current
+  directory for a '.config' file to be to be added under the management of kw.
+  The save option expects a name to be used as a alias for the target config
+  file. If we have a local '.config' and a valid name, kw saves the
+  configuration file. Additionally, users can add a description by using '-d'
+  flag. Finally, if the user tries to add the same name twice kw will warn
+  about it; the '-f' will suppress this message.
+
+- `--ls` list all the config files available.
 
 # Tests
 

--- a/kw
+++ b/kw
@@ -4,7 +4,8 @@
 EASY_KERNEL_WORKFLOW=${EASY_KERNEL_WORKFLOW:-"kw"}
 src_script_path=${src_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/src"}
 external_script_path=${external_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/external"}
-config_files_path=${config_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/etc"}
+etc_files_path=${etc_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/etc"}
+config_files_path=${config_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW"}
 
 # Export external variables required by kworkflow
 export EASY_KERNEL_WORKFLOW
@@ -125,6 +126,13 @@ function kw()
         . $src_script_path/get_maintainer_wrapper.sh --source-only
 
         execute_get_maintainer $@
+      )
+      ;;
+    configm|g)
+      (
+        . $src_script_path/config_manager.sh --source-only
+
+        execute_config_manager $@
       )
       ;;
     help|h)

--- a/src/commons.sh
+++ b/src/commons.sh
@@ -59,7 +59,7 @@ function load_configuration()
   local local_config_path=$PWD/kworkflow.config
 
   # First, load the global configuration
-  parse_configuration $config_files_path/kworkflow.config
+  parse_configuration $etc_files_path/kworkflow.config
 
   # Second, check if has a local file and override values
   if [ -f $local_config_path ] ; then

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -1,0 +1,121 @@
+. $src_script_path/kwio.sh --source-only
+
+declare -r metadata_dir="metadata"
+declare -r configs_dir="configs"
+
+# This function handles the save operation of kernel's '.config' file. It
+# checks if the '.config' exists and saves it using git (dir.:
+# <kw_install_path>/configs)
+#
+# @force Force option. If it is set and the current name was already saved,
+#        this option will override the '.config' file under the 'name'
+#        specified by '-n' without any message.
+# @name This option specifies a name for a target .config file. This name
+#       represents the access key for .config.
+# @description Description for a config file, de descrition from '-d' flag.
+function save_config_file()
+{
+  local ret=0
+  local -r force=$1
+  local -r name=$2
+  local -r description=$3
+  local -r original_path=$PWD
+  local -r dot_configs_dir="$config_files_path/configs"
+
+  if [[ ! -f $original_path/.config ]]; then
+    complain "There's no .config file in the current directory"
+    exit 2 # ENOENT
+  fi
+
+  if [[ ! -d $dot_configs_dir ]]; then
+    mkdir $dot_configs_dir
+    cd $dot_configs_dir
+    git init --quiet
+    mkdir $metadata_dir $configs_dir
+  fi
+
+  cd $dot_configs_dir
+
+  # Check if the metadata related to .config file already exists
+  if [[ ! -f $metadata_dir/$name ]]; then
+    touch $metadata_dir/$name
+  elif [[ $force != 1 ]]; then
+    if [[ $(ask_yN "$name already exists. Update?") =~ "0" ]]; then
+      complain "Save operation aborted"
+      cd $original_path
+      exit 0
+    fi
+  fi
+
+  if [[ ! -z $description ]]; then
+    echo $description > $metadata_dir/$name
+  fi
+
+  cp $original_path/.config $dot_configs_dir/$configs_dir/$name
+  git add $configs_dir/$name $metadata_dir/$name
+  git commit -m "New config file added: $USER - $(date)" > /dev/null 2>&1
+
+  if [[ "$?" == 1 ]]; then
+    warning "Warning: $name: there's nothing new in this file"
+  else
+    success "Saved $name"
+  fi
+
+  cd $original_path
+}
+
+function list_configs()
+{
+  local -r dot_configs_dir="$config_files_path/configs"
+
+  if [[ ! -d $dot_configs_dir ]]; then
+    say "There's no tracked .config file"
+    exit 0
+  fi
+
+  echo -e "Name\t\tDescription"
+  echo -e "----\t\t------------"
+  for filename in $dot_configs_dir/$metadata_dir/*; do
+    local name=$(basename $filename)
+    local content=$(cat $filename)
+    echo -n $name
+    echo -e "\t\t$content"
+  done
+}
+
+# This function handles the options available in 'configm'.
+#
+# @* This parameter expects a list of parameters, such as '-n', '-d', and '-f'.
+#
+# Returns:
+# Return 0 if everything ends well, otherwise return an errno code.
+function execute_config_manager()
+{
+  local name_config
+  local description_config
+  local force=0
+
+  [[ "$@" =~ "-f" ]] && force=1
+
+  case $1 in
+    --save)
+      shift # Skip '--save' option
+      name_config=$1
+      # Validate string name
+      if [[ "$name_config" =~ ^- || -z "${name_config// }" ]]; then
+        complain "Invalid argument"
+        exit 22 # EINVAL
+      fi
+      # Shift name and get '-d'
+      shift && description_config=$@
+      save_config_file $force $name_config "$description_config"
+      ;;
+    --ls)
+      list_configs
+      ;;
+    *)
+      complain "Unknown option"
+      exit 22 #EINVAL
+      ;;
+  esac
+}

--- a/src/help.sh
+++ b/src/help.sh
@@ -24,4 +24,8 @@ function kworkflow-help()
     "\t                             prints files authors\n" \
     "\texplore,e - Search for expression on git log or directory\n" \
     "\thelp,h - displays this help mesage"
+
+  echo -e "\nkw config manager:\n" \
+    "\tconfigm,g --save NAME [-d 'DESCRIPTION']\n" \
+    "\tconfigm,g --ls - List config files under kw management\n"
 }

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -86,3 +86,24 @@ function success()
 {
     colored_print GREENCOLOR "$@"
 }
+
+# Ask for yes or no
+#
+# @message A string with the message to be displayed for the user.
+#
+# Returns:
+# Return "1" if the user accept the question, otherwise, return "0"
+#
+# Note: ask_yN return the string '1' and '0', you have to handle it by
+# yourself in the code.
+function ask_yN()
+{
+  local message=$1
+
+  read -r -p "$message [y/N] " response
+  if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+
+. ./src/config_manager.sh --source-only
+. ./tests/utils --source-only
+
+LS_TITLE="Name\t\tDescription"
+COMMAND_MSG_UNKNOWN="Unknown option"
+COMMAND_MSG_INVALID_ARG="Invalid argument"
+
+readonly YES_FORCE="1"
+readonly NO_FORCE="0"
+
+readonly CONTENT="The content"
+
+readonly NAME_1="test_save_1"
+readonly NAME_2="test_save_2"
+
+readonly DESCRIPTION_1="This is the first description"
+readonly DESCRIPTION_2="Hi, I'm the second description"
+
+readonly LS_NO_FILES="There's no tracked .config file"
+
+function suite
+{
+  suite_addTest "execute_config_manager_SAVE_fails_test"
+  suite_addTest "save_config_file_CHECK_CONFIG_fails_test"
+  suite_addTest "save_config_file_CHECK_CONFIGS_DIRECTORY_test"
+  suite_addTest "save_config_file_CHECK_SAVED_CONFIG_FILE_test"
+  suite_addTest "save_config_file_CHECK_DESCRIPTION_test"
+  suite_addTest "save_config_file_CHECK_GIT_SAVE_SCHEMA_test"
+  suite_addTest "save_config_file_CHECK_FORCE_test"
+  suite_addTest "list_configs_CHECK_NO_CONFIGS_test"
+  suite_addTest "list_configs_OUTPUT_test"
+}
+
+function setupConfigm()
+{
+  local -r test_path="tests/.tmp"
+  local -r current_path=$PWD
+
+  rm -rf $test_path
+
+  mkdir -p $test_path
+  cd $test_path
+  touch .config
+  echo $CONTENT > .config
+  cd $current_path
+}
+
+function tearDownConfigm()
+{
+  local -r test_path="tests/.tmp"
+
+  rm -rf $test_path
+}
+
+function test_expected_string()
+{
+  local msg="$1"
+  local expected="$2"
+  local target="$3"
+
+  assertEquals "$msg" "$target" "$expected"
+}
+
+function execute_config_manager_SAVE_fails_test
+{
+  local msg_prefix=" --save"
+
+  ret=$(execute_config_manager --save)
+  test_expected_string "$msg_prefix" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save --lala)
+  test_expected_string "$msg_prefix --lala" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -n)
+  test_expected_string "$msg_prefix -n" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -d)
+  test_expected_string "$msg_prefix -d" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -n -d)
+  test_expected_string "$msg_prefix -n -d" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -n -lulu)
+  test_expected_string "$msg_prefix -n -lulu" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -d)
+  test_expected_string "$msg_prefix -d" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -d "lalala and xpto")
+  test_expected_string "$msg_prefix -d" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --save -f)
+  test_expected_string "$msg_prefix -f" "$COMMAND_MSG_INVALID_ARG" "$ret"
+}
+
+function save_config_file_CHECK_CONFIG_fails_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local force=0
+  local ret=0
+
+  # Prepare teste
+  setupConfigm
+
+  # Test without config file -> should fail
+  cd $test_path
+  rm -f .config
+  ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  assertEquals "No .config file should return ENOENT" "$?" "2"
+
+  # Test with different name
+  touch .configuration
+  ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  assertEquals "Should return ENOENT, because '.config' != '.configuration'" "$?" "2"
+  rm .configuration
+
+  cd $current_path
+  tearDownConfigm
+}
+
+function save_config_file_CHECK_CONFIGS_DIRECTORY_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  $(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  cd $current_path
+
+  # Check if all the expected files were created
+  assertTrue "The configs dir was not created" '[[ -d $config_files_path/configs ]]'
+  assertTrue "The repository configs does not have .git" '[[ -d $config_files_path/configs/.git ]]'
+  assertTrue "The metadata dir is not available" '[[ -d $config_files_path/configs/metadata ]]'
+  assertTrue "The configs dir is not available" '[[ -d $config_files_path/configs/configs ]]'
+
+  tearDownConfigm
+}
+
+function save_config_file_CHECK_SAVED_CONFIG_FILE_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  cd $current_path
+
+  assertTrue "Failed to find $NAME_1" '[[ -f $config_files_path/configs/configs/$NAME_1 ]]'
+  assertTrue "Failed the metadata related to $NAME_1" '[[ -f $config_files_path/configs/metadata/$NAME_1 ]]'
+
+  cd $test_path
+  ret=$(save_config_file $NO_FORCE $NAME_2)
+  cd $current_path
+
+  assertTrue "Failed to find $NAME_2" '[[ -f $config_files_path/configs/configs/$NAME_2 ]]'
+  assertTrue "Failed the metadata related to $NAME_2" '[[ -f $config_files_path/configs/metadata/$NAME_2 ]]'
+
+  local tmp=$(cat $config_files_path/configs/configs/$NAME_2)
+  assertTrue "Content in the file does not match" '[[ $tmp = $CONTENT ]]'
+
+  tearDownConfigm
+}
+
+function save_config_file_CHECK_DESCRIPTION_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  cd $current_path
+
+  local tmp=$(cat $config_files_path/configs/metadata/$NAME_1)
+  assertTrue "The description content for $NAME_1 does not match" '[[ $tmp = $DESCRIPTION_1 ]]'
+
+  cd $test_path
+  ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
+  cd $current_path
+
+  tmp=$(cat $config_files_path/configs/metadata/$NAME_2)
+  assertTrue "The description content for $NAME_2 does not match" '[[ $tmp = $DESCRIPTION_2 ]]'
+
+  tearDownConfigm
+}
+
+function save_config_file_CHECK_GIT_SAVE_SCHEMA_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
+  ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
+  cd "configs"
+  ret=$(git rev-list --all --count)
+  cd $current_path
+
+  assertTrue "We expected 2 commits, but we got $ret" '[[ $ret = "2" ]]'
+
+  tearDownConfigm
+}
+
+function save_config_file_CHECK_FORCE_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
+  ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
+  cd $current_path
+  assertTrue "We expected no changes" '[[ $ret =~ Warning ]]'
+
+  tearDownConfigm
+}
+
+function list_configs_CHECK_NO_CONFIGS_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  ret=$(list_configs)
+  assertTrue "We expected no changes" '[[ $ret =~ $LS_NO_FILES ]]'
+
+  tearDownConfigm
+}
+
+function list_configs_OUTPUT_test()
+{
+  local -r test_path="tests/.tmp"
+  local current_path=$PWD
+  local ret=0
+  config_files_path=$current_path/$test_path
+
+  setupConfigm
+
+  # There's no configs yet, initialize it
+  cd $test_path
+  ret=$(save_config_file $YES_FORCE $NAME_1 "$DESCRIPTION_1")
+  ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
+  cd $current_path
+
+  # There's no configs yet, initialize it
+  ret=$(list_configs)
+  assertTrue "We expected 'Name' in the output, but we got $ret" '[[ $ret =~ Name ]]'
+  assertTrue "We expected 'Description' in the output, but we got $ret" '[[ $ret =~ Description ]]'
+  assertTrue "We expected $NAME_1 in the output, but we got $ret" '[[ $ret =~ $NAME_1 ]]'
+  assertTrue "We expected $DESCRIPTION_1 in the output, but we got $ret" '[[ $ret =~ $DESCRIPTION_1 ]]'
+  assertTrue "We expected $NAME_2 in the output, but we got $ret" '[[ $ret =~ $NAME_2 ]]'
+  assertTrue "We expected $DESCRIPTION_2 in the output, but we got $ret" '[[ $ret =~ $DESCRIPTION_2 ]]'
+
+  tearDownConfigm
+}
+
+invoke_shunit


### PR DESCRIPTION
This commit adds the configure manager (configm) option, which is
responsible for administering the '.config' files for users. This commit
introduces the basic structure for configm followed by the save and list
operation. Additionally, the README and the unit tests were updated to
describe this feature better.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>