### PR TITLE
Turns `kw.sh` into a driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ following dependencies:
 * libguestfs
 * Qemu
 * Ansible
+* Bash
 
 > If you want to use the default alert system (for commands that may take longer
 to run), you will also need to install:
 
 * paplay
 * notify-send
+
+> For development, you will need the additional packages:
+
+* dash
 
 ## Recommendations
 
@@ -48,8 +53,12 @@ your `.bashrc`:
 
 ```
 # kw
-source /home/<user>/.config/kw/kw.sh
+PATH=$PATH:/home/<user>/.config/kw
+source /home/<user>/.config/kw/src/bash_autocomplete.sh
 ```
+
+> If you use another shell (`ksh`, for example), you will need to manually add
+the path to `kw` to `PATH` environment variable.
 
 > To check if the installations was ok, type:
 

--- a/kw
+++ b/kw
@@ -9,36 +9,6 @@ config_files_path=${config_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/etc"
 # Export external variables required by kworkflow
 export EASY_KERNEL_WORKFLOW
 
-_kw_autocomplete()
-{
-    local current_command previous_command kw_options
-    COMPREPLY=()
-    current_command="${COMP_WORDS[COMP_CWORD]}"
-    previous_command="${COMP_WORDS[COMP_CWORD-1]}"
-    kw_options="export e build b bi install i prepare p new n ssh s
-                mail mount mo umount um boot bo vars v up u codestyle c
-                maintainers m help h"
-
-    # By default, autocomplete with kw_options
-    if [[ ${previous_command} == kw ]] ; then
-        COMPREPLY=( $(compgen -W "${kw_options}" -- ${current_command}) )
-        return 0
-    fi
-
-    # TODO:
-    # Autocomplete in the bash terminal is a powerful tool which allows us to
-    # make many interesting things. In the future, we could add an
-    # autocompletion for subcommands, the code below illustrates an example
-    # that tries to add this feature for the ‘maintainers’ options.
-    #
-    # For maintainers and m options, autocomplete with folder
-    # if [ ${previous_command} == maintainers ] || [ ${previous_command} == m ] ; then
-    #   COMPREPLY=( $(compgen -d -- ${current_command}) )
-    #   return 0
-    # fi
-}
-complete -o default -F _kw_autocomplete kw
-
 function kw()
 {
   action=$1
@@ -183,3 +153,5 @@ function kw()
       ;;
   esac
 }
+
+kw $@

--- a/setup.sh
+++ b/setup.sh
@@ -12,6 +12,7 @@ declare -r INSTALLTO="$HOME/.config/$APPLICATIONNAME"
 
 declare -r EXTERNAL_SCRIPTS="external"
 declare -r SOUNDS="sounds"
+declare -r BASH_AUTOCOMPLETE="bash_autocomplete"
 
 . src/kwio.sh --source-only
 
@@ -55,7 +56,7 @@ function synchronize_files()
   mkdir -p $INSTALLTO
 
   # Copy the script
-  cp $APPLICATIONNAME.sh $INSTALLTO
+  cp $APPLICATIONNAME $INSTALLTO
   rsync -vr $SRCDIR $INSTALLTO
   rsync -vr $DEPLOY_DIR $INSTALLTO
   rsync -vr $SOUNDS $INSTALLTO
@@ -64,9 +65,14 @@ function synchronize_files()
   rsync -vr $CONFIG_DIR $INSTALLTO
   setup_config_file
 
-  # Add to bashrc
-  echo "# $APPLICATIONNAME" >> $HOME/.bashrc
-  echo "source $INSTALLTO/$APPLICATIONNAME.sh" >> $HOME/.bashrc
+  if [ -f "$HOME/.bashrc" ]; then
+      # Add to bashrc
+      echo "# $APPLICATIONNAME" >> $HOME/.bashrc
+      echo "PATH=\$PATH:$INSTALLTO" >> $HOME/.bashrc
+      echo "source $INSTALLTO/$SRCDIR/$BASH_AUTOCOMPLETE.sh" >> $HOME/.bashrc
+  else
+      warning "Unable to find a shell."
+  fi
 
   say $SEPARATOR
   say "$APPLICATIONNAME installed into $INSTALLTO"

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+_kw_autocomplete()
+{
+    local current_command previous_command kw_options
+    COMPREPLY=()
+    current_command="${COMP_WORDS[COMP_CWORD]}"
+    previous_command="${COMP_WORDS[COMP_CWORD-1]}"
+    kw_options="export e build b bi install i prepare p new n ssh s
+                mail mount mo umount um boot bo vars v up u codestyle c
+                maintainers m help h"
+
+    # By default, autocomplete with kw_options
+    if [[ ${previous_command} == kw ]] ; then
+        COMPREPLY=( $(compgen -W "${kw_options}" -- ${current_command}) )
+        return 0
+    fi
+
+    # TODO:
+    # Autocomplete in the bash terminal is a powerful tool which allows us to
+    # make many interesting things. In the future, we could add an
+    # autocompletion for subcommands, the code below illustrates an example
+    # that tries to add this feature for the ‘maintainers’ options.
+    #
+    # For maintainers and m options, autocomplete with folder
+    # if [ ${previous_command} == maintainers ] || [ ${previous_command} == m ] ; then
+    #   COMPREPLY=( $(compgen -d -- ${current_command}) )
+    #   return 0
+    # fi
+}
+complete -o default -F _kw_autocomplete kw

--- a/tests/_kw_dash.dsh
+++ b/tests/_kw_dash.dsh
@@ -1,0 +1,3 @@
+#!/bin/dash
+
+./kw h > /dev/null

--- a/tests/kw_dash.sh
+++ b/tests/kw_dash.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. ./tests/utils --source-only
+
+function suite
+{
+  suite_addTest "testDash"
+}
+
+function testDash
+{
+  ./tests/_kw_dash.dsh
+  if [ $? -ne 0 ]; then
+    fail "Dash was unable to find kw"
+  fi
+}
+
+invoke_shunit

--- a/tests/kw_test.sh
+++ b/tests/kw_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 . ./tests/utils --source-only
-. ./kw.sh --source-only
+. ./kw --source-only > /dev/null
 
 function suite
 {


### PR DESCRIPTION
This commits makes `kw.sh` a script that do not requires sourcing to be
used. Although this commit does not explicitly add support to other
shells than bash, it makes `kw` callable from other shells. As a proof
of concept, a new test was added calling `kw` from dash.

Signed-off-by: Giuliano Belinassi <giuliano.belinassi@usp.br>