### PR TITLE
Remove depecrated commands from bash autocomplete

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -6,7 +6,7 @@ _kw_autocomplete()
     COMPREPLY=()
     current_command="${COMP_WORDS[COMP_CWORD]}"
     previous_command="${COMP_WORDS[COMP_CWORD-1]}"
-    kw_options="export e build b bi install i prepare p new n ssh s
+    kw_options="explore e build b bi install i prepare p new n ssh s
                 mount mo umount um vars v up u codestyle c
                 maintainers m help h"
 

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -7,7 +7,7 @@ _kw_autocomplete()
     current_command="${COMP_WORDS[COMP_CWORD]}"
     previous_command="${COMP_WORDS[COMP_CWORD-1]}"
     kw_options="export e build b bi install i prepare p new n ssh s
-                mail mount mo umount um boot bo vars v up u codestyle c
+                mount mo umount um vars v up u codestyle c
                 maintainers m help h"
 
     # By default, autocomplete with kw_options


### PR DESCRIPTION
Remove the following deprecated commands completions for bash: mail, boot, bo.

There's a test case (testExplore) that fails. However, that case fails even in the unstable branch on my machine. I'm using shunit 2.7.1 and bash 5.0.2.