### PR TITLE
src: vm: Add support to execute commands/scripts via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ kw vars|v
 ```
 kw up|u
 ```
+> Based on the kworkflow.config file tries to perform ssh operation such as
+> login into the VM or execute a host script in the VM.
+> Note: The `--script` parameter, only evaluate bash scripts
+
+```
+kw ssh|s [--script|-s="SCRIPT PATH"]
+kw ssh|s [--command|-c="COMMAND"]
+```
 
 > Run checkpatch in a target (directory of file):
 

--- a/kw
+++ b/kw
@@ -104,7 +104,7 @@ function kw()
       (
         . $src_script_path/vm.sh --source-only
 
-        vm_ssh
+        vm_ssh $@
       )
       ;;
     vars|v)

--- a/src/help.sh
+++ b/src/help.sh
@@ -13,7 +13,6 @@ function kworkflow-help()
     "\tbi - Build and install modules\n" \
     "\tprepare,p - Deploy basic environment in the VM\n" \
     "\tnew,n - Install new Kernel image\n" \
-    "\tssh,s - Enter in the vm\n" \
     "\tmount,mo - Mount partition with qemu-nbd\n" \
     "\tumount,um - Umount partition created with qemu-nbd\n" \
     "\tvars,v - Show variables\n" \
@@ -28,4 +27,8 @@ function kworkflow-help()
   echo -e "\nkw config manager:\n" \
     "\tconfigm,g --save NAME [-d 'DESCRIPTION']\n" \
     "\tconfigm,g --ls - List config files under kw management\n"
+
+  echo -e "kw ssh|s options:\n" \
+    "\tssh|s [--script|-s="SCRIPT PATH"]\n" \
+    "\tssh|s [--command|-c="COMMAND"]\n"
 }

--- a/tests/samples/dmesg
+++ b/tests/samples/dmesg
@@ -1,0 +1,5 @@
+if [ "$#" -gt 0 ]; then
+  dmesg $@;
+else
+  dmesg -wH --color='always';
+fi

--- a/tests/ssh_test.sh
+++ b/tests/ssh_test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+#
+# NOTE: We're not testing the ssh command here, just the kw ssh operation
+#
+
+. ./src/vm.sh --source-only
+. ./tests/utils --source-only
+
+INVALID_ARG="Invalid arguments"
+NO_SUCH_FILE="No such file"
+TEST_PATH="tests/.tmp"
+
+SSH_OK="ssh -p 3333 127.0.0.1"
+
+function suite
+{
+  suite_addTest "vmSshFailsTest"
+  suite_addTest "vmSshTest"
+  suite_addTest "vmSshCommandTest"
+  suite_addTest "vmSshScriptTest"
+}
+
+function setupSsh
+{
+  local -r current_path=$PWD
+
+  rm -rf $TEST_PATH
+
+  mkdir -p $TEST_PATH
+
+  cp -f tests/samples/kworkflow.config $TEST_PATH
+  cp -f tests/samples/dmesg $TEST_PATH
+
+  cd $TEST_PATH
+  load_configuration
+  cd $current_path
+}
+
+function tearDownSsh
+{
+  rm -rf $TEST_PATH
+}
+
+function vmSshFailsTest
+{
+  setupSsh
+
+  local args="--lala"
+  local ret=$(vm_ssh $args)
+
+  assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
+
+  args="-m"
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
+
+  args="-d="
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
+
+  args="-c"
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
+
+  args="-s"
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
+
+  args="-s="
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$NO_SUCH_FILE\", but we got \"$ret\"" '[[ $ret =~ "$NO_SUCH_FILE" ]]'
+
+  args="--script="
+  ret=$(vm_ssh $args)
+  assertTrue "We expected a substring \"$NO_SUCH_FILE\", but we got \"$ret\"" '[[ $ret =~ "$NO_SUCH_FILE" ]]'
+
+  tearDownSsh
+}
+
+function vmSshTest
+{
+  setupSsh
+
+  ret=$(vm_ssh 2>&1)
+
+  assertTrue "We expected a substring \"$SSH_OK\", but we got \"$ret\"" '[[ $ret =~ "$SSH_OK" ]]'
+
+  tearDownSsh
+}
+
+function vmSshCommandTest
+{
+  setupSsh
+
+  ret=$(vm_ssh -c="pwd" 2>&1)
+  msg="$SSH_OK pwd"
+  assertTrue "We expected a substring \"$msg\", but we got \"$ret\"" '[[ $ret =~ "$msg" ]]'
+
+  ret=$(vm_ssh --command="ls /etc/" 2>&1)
+  msg="$SSH_OK ls /etc/"
+  assertTrue "We expected a substring \"$msg\", but we got \"$ret\"" '[[ $ret =~ "$msg" ]]'
+
+  tearDownSsh
+}
+
+function vmSshScriptTest
+{
+  setupSsh
+
+  ret=$(vm_ssh -s="/not/a/valid/path/xpto" 2>&1)
+  msg="$NO_SUCH_FILE: \"/not/a/valid/path/xpto\""
+  assertTrue "We expected a substring \"$msg\", but we got \"$ret\"" '[[ $ret =~ "$msg" ]]'
+
+  ret=$(vm_ssh -s="$TEST_PATH/dmesg" 2>&1)
+  msg="$SSH_OK \"bash -s\" -- < $TEST_PATH/dmesg"
+  assertTrue "We expected a substring \"$msg\", but we got \"$ret\"" '[[ $ret =~ "$msg" ]]'
+
+  tearDownSsh
+}
+
+invoke_shunit


### PR DESCRIPTION
This commit adds the capability of executing commands or scripts via kw
s. We have two options:

 1. Commands: the command to be executed inside the VM
 2. Scripts: A script in the host machine to be executed in the VM.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>