### PR TITLE
Add fish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ to run), you will also need to install:
 
 * dash
 * shunit2
+* fish
 
 ## Recommendations
 
@@ -58,6 +59,14 @@ your `.bashrc`:
 # kw
 PATH=$PATH:/home/<user>/.config/kw
 source /home/<user>/.config/kw/src/bash_autocomplete.sh
+```
+
+> If you use `fish`, this command will move `src/kw.fish` to
+`~/.config/fish/completions`, and will add the following line at the end of your
+`config.fish`, in order to add `kw` to `PATH`:
+
+```
+set -gx PATH $PATH:/home/lso/.config/kw
 ```
 
 > If you use another shell (`ksh`, for example), you will need to manually add

--- a/setup.sh
+++ b/setup.sh
@@ -15,6 +15,9 @@ declare -r SOUNDS="sounds"
 declare -r BASH_AUTOCOMPLETE="bash_autocomplete"
 declare -r DOCUMENTATION="documentation"
 
+declare -r FISH_CONFIG_PATH="$HOME/.config/fish"
+declare -r FISH_COMPLETION_PATH="$FISH_CONFIG_PATH/completions"
+
 declare -r CONFIGS_PATH="configs"
 
 . src/kwio.sh --source-only
@@ -67,6 +70,19 @@ function setup_config_file()
 
 }
 
+function synchronize_fish()
+{
+    local kw_fish_path='set -gx PATH $PATH:/home/lso/.config/kw'
+
+    say "Fish detected. Setting up fish support."
+    mkdir -p $FISH_COMPLETION_PATH
+    rsync -vr $SRCDIR/kw.fish $FISH_COMPLETION_PATH/kw.fish
+
+    if ! grep -F "$kw_fish_path" $FISH_CONFIG_PATH/config.fish; then
+       echo $kw_fish_path >> $FISH_CONFIG_PATH/config.fish
+    fi
+}
+
 # Synchronize .vim and .vimrc with repository.
 function synchronize_files()
 {
@@ -92,6 +108,10 @@ function synchronize_files()
       echo "source $INSTALLTO/$SRCDIR/$BASH_AUTOCOMPLETE.sh" >> $HOME/.bashrc
   else
       warning "Unable to find a shell."
+  fi
+
+  if command -v fish &> /dev/null; then
+      synchronize_fish
   fi
 
   say $SEPARATOR

--- a/src/kw.fish
+++ b/src/kw.fish
@@ -1,0 +1,30 @@
+#!/usr/bin/env fish
+
+# Test if the kw command has subcommands
+function __fish_kw_no_commands
+    set cmd (commandline -opc)
+    if [ "$cmd" = "kw" ]
+        return 0
+    end
+
+    return 1
+end
+
+# Disable file completion when there's no specified command
+complete -c kw -n __fish_kw_no_commands -f
+
+# kw commands
+complete -c kw -n "__fish_kw_no_commands" -a "build b" -d "Build Kernel and modules"
+complete -c kw -n "__fish_kw_no_commands" -a "install i" -d "Install modules"
+complete -c kw -n "__fish_kw_no_commands" -a "bi" -d "Build and install modules"
+complete -c kw -n "__fish_kw_no_commands" -a "prepare p" -d "Deploy basic environment in the VM"
+complete -c kw -n "__fish_kw_no_commands" -a "new n" -d "Install new Kernel image"
+complete -c kw -n "__fish_kw_no_commands" -a "ssh s" -d "Enter in the vm"
+complete -c kw -n "__fish_kw_no_commands" -a "mount mo" -d "Mount partition with qemu-nbd"
+complete -c kw -n "__fish_kw_no_commands" -a "umount um" -d "Umount partition created with qemu-nbd"
+complete -c kw -n "__fish_kw_no_commands" -a "vars v" -d "Show variables"
+complete -c kw -n "__fish_kw_no_commands" -a "up u" -d "Wake up vm"
+complete -c kw -n "__fish_kw_no_commands" -a "codestyle c" -d "Apply checkpatch on directory or file"
+complete -c kw -n "__fish_kw_no_commands" -a "maintainers m" -d "Return the maintainers and the mailing list"
+complete -c kw -n "__fish_kw_no_commands" -a "explore e" -d "Search for expression on git log or directory"
+complete -c kw -n "__fish_kw_no_commands" -a "help h" -d "Display this help mesage"

--- a/tests/fish_completion_test.sh
+++ b/tests/fish_completion_test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+. ./tests/utils --source-only
+
+function suite()
+{
+    suite_addTest "testKwCompletion"
+}
+
+function getSortedCompletions()
+{
+    local env_path=".:/bin"
+    local env_fish_complete_path=""
+    local completion="./src/kw.fish"
+    local cmd=$1
+    local fish_cmd="set PATH $env_path;
+                    set fish_complete_path $env_fish_complete_path;
+                    source $completion;
+                    complete -C'$1 '"
+
+    fish -c "$fish_cmd" | awk '{print $1}' | sort
+}
+
+function testKwCompletion()
+{
+    local kw_options="explore e build b bi install i prepare p new n ssh s
+                      mount mo umount um vars v up u codestyle c
+                      maintainers m help h"
+
+    local sorted_kw_options="$(echo $kw_options | awk '{gsub(" ", "\n"); print $0}' | sort)"
+    local sorted_kw_fish_completions="$(getSortedCompletions 'kw')"
+
+    if [[ "$sorted_kw_fish_completions" != "$sorted_kw_options" ]]; then
+	local difference="$(diff <(echo "$sorted_kw_options") <(echo "$sorted_kw_fish_completions"))"
+	fail "Fish suggestions and kw commands are not the same:\n$difference"
+    fi;
+
+}
+
+invoke_shunit


### PR DESCRIPTION
This is a fresher version of https://github.com/rodrigosiqueira/kworkflow/pull/88.

With this PR, `setup.sh` -i will configure `fish` for using `kw`, putting the completion file in the correct place, and adding `kw` to `fish` `PATH` variable.
