### PR TITLE
src: checkpatch_wrapper: make 'kw codestyle' to use kernel tree script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,6 @@ declare -r DEPLOY_DIR="deploy_rules"
 declare -r CONFIG_DIR="etc"
 declare -r INSTALLTO="$HOME/.config/$APPLICATIONNAME"
 
-declare -r EXTERNAL_SCRIPTS="external"
 declare -r SOUNDS="sounds"
 declare -r BASH_AUTOCOMPLETE="bash_autocomplete"
 declare -r DOCUMENTATION="documentation"
@@ -119,44 +118,12 @@ function synchronize_files()
   say $SEPARATOR
 }
 
-function download_stuff()
-{
-  URL=$1
-  PATH_TO=$2
-  ret=$(wget $URL -P $PATH_TO)
 
-  if [ "$?" != 0 ] ; then
-    warning "Problem to download, verify your connection"
-    warning "kw is not full installed"
-  fi
-}
-
-function get_external_scripts()
-{
-  local ret
-
-  local -r CHECKPATCH_URL="https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl"
-  local -r CHECKPATCH_CONST_STRUCTS="https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch"
-  local -r CHECKPATCH_SPELLING="https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt"
-
-  say "Download and install external scripts..."
-  echo
-
-  mkdir -p $INSTALLTO/$EXTERNAL_SCRIPTS
-  CHECKPATCH_TARGET_PATH=$INSTALLTO/$EXTERNAL_SCRIPTS
-  download_stuff $CHECKPATCH_URL $CHECKPATCH_TARGET_PATH
-  download_stuff $CHECKPATCH_CONST_STRUCTS $CHECKPATCH_TARGET_PATH
-  download_stuff $CHECKPATCH_SPELLING $CHECKPATCH_TARGET_PATH
-
-  echo
-}
 
 function install_home()
 {
   # First clean old installation
   clean_legacy
-  # Download external scripts
-  get_external_scripts
   # Synchronize of vimfiles
   synchronize_files
 }

--- a/src/checkpatch_wrapper.sh
+++ b/src/checkpatch_wrapper.sh
@@ -1,4 +1,5 @@
-. $src_script_path/kwio.sh --source-only
+. $src_script_path/commons.sh --source-only
+. $src_script_path/kwlib.sh --source-only
 
 function execute_checkpatch()
 {
@@ -10,17 +11,35 @@ function execute_checkpatch()
   # --codespell $external_script_path/spelling.txt
 
   local -r options="--terse --no-tree --color=always -strict --file "
-  local -r checkpatch="perl $external_script_path/checkpatch.pl $options"
+  local kernel_root=""
+  local -r script="scripts/checkpatch.pl $options"
+  local -r original_working_dir=$PWD
 
+  if [[ -z $FILE_OR_DIR_CHECK ]]; then
+    FILE_OR_DIR_CHECK="."
+  fi
+
+  FILE_OR_DIR_CHECK="$(realpath $FILE_OR_DIR_CHECK)"
   # Check if is a valid path
-  if [ ! -d $FILE_OR_DIR_CHECK -a ! -f $FILE_OR_DIR_CHECK ]; then
+  if [[ ! -d $FILE_OR_DIR_CHECK && ! -f $FILE_OR_DIR_CHECK ]]; then
     complain "Invalid path"
     return 1
   fi
 
+  # try to find kernel root at given path
+  kernel_root="$(find_kernel_root $FILE_OR_DIR_CHECK)"
+  if [[ -z "$kernel_root" ]]; then
+    # fallback: try to find kernel root at working path
+    kernel_root="$(find_kernel_root $original_working_dir)"
+  fi
+
+  # Check if kernel root was found.
+  if [[ -z "$kernel_root" ]]; then
+    complain "Neither the given path nor the working path is in a kernel tree."
+    return 1
+  fi  
   # Build a list of file to apply check patch
   FLIST=`find $FILE_OR_DIR_CHECK -type f ! -name '*\.mod\.c' | grep "\.[ch]$" `
-
   say "Running checkpatch.pl on: $FILE_OR_DIR_CHECK"
   say $SEPARATOR
 
@@ -34,7 +53,9 @@ function execute_checkpatch()
       continue
     fi
 
-    $checkpatch $file
+    cd $kernel_root
+    eval perl $script $file
+    cd $original_working_dir
 
     if [ $? != 0 ]; then
       say $SEPARATOR


### PR DESCRIPTION
Now 'kw codestyle' runs kernel-tree script 'scripts/checkpatch.pl'
instead of using downloaded external script and is able to run
in every directory as 'kw maintainers' works.

Since none external script is needed, we disable downloading external
script in 'setup.sh'

Fixes #40 