### PR TITLE
src: explore: add support to work with multiple strings

### DIFF
--- a/kw
+++ b/kw
@@ -168,4 +168,4 @@ function kw()
   esac
 }
 
-kw $@
+kw "$@"

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -1,4 +1,5 @@
 . $src_script_path/kwio.sh --source-only
+. $src_script_path/kwlib.sh --source-only
 
 function explore()
 {
@@ -15,11 +16,12 @@ function explore()
       (
         local path=${@:2}
         local regex=$1
+	# If user only set regex value
         if [[ $# -eq 1 ]]; then
           path="."
           regex=$1
         fi
-        git grep -e $regex -nI $path
+        cmd_manager "git grep -e \"$regex\" -nI $path"
       );;
   esac
 }

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -17,6 +17,8 @@ function testExplore
   MSG_OUT="camel_case(void)"
   assertEquals "$MSG_OUT" "$(explore "camel_case" tests/samples | cut -d ' ' -f2 | sed -n -e 2p)"
   assertEquals "$LOG_OUT" "$(explore log LICENSE | grep "Initial commit" | awk '{print $1, $2}')"
+  MSG_OUT="Free Software Foundation"  
+  assertEquals "$MSG_OUT" "$(explore "Free Software Foundation" ./LICENSE | grep "Free Software Foundation" -o | head -n 1)"
   true
 }
 

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -15,7 +15,7 @@ function testExplore
 
   assertEquals "Expected an error message." "Expected path or 'log'" "$(explore)"
   MSG_OUT="camel_case(void)"
-  assertEquals "$MSG_OUT" "$(explore "camel_case" tests/samples | cut -d ' ' -f2 | head -n 1)"
+  assertEquals "$MSG_OUT" "$(explore "camel_case" tests/samples | cut -d ' ' -f2 | sed -n -e 2p)"
   assertEquals "$LOG_OUT" "$(explore log LICENSE | grep "Initial commit" | awk '{print $1, $2}')"
   true
 }


### PR DESCRIPTION
Now "kw explore" supports multiple strings as patterns to be used
    on "git grep". The new rules for "kw explore" are as follow:
    1) If you type two or more arguments and the last argument is a
    valid file/directory, it will perform a git-grep using all arguments
    but last as patterns and the last argument as pathspec. If the last
    argument not a valid file/directory, all argument will be used as
    patterns and pathspec will be ".".
    2) If you type just one argument, it will perform a git-grep using
    that argument as pattern and "." as pathspec.
    
Fixes #91 