### PR TITLE
src: mk: remove unnecessary multiplication of PARALLEL_CORES

### DIFF
--- a/src/mk.sh
+++ b/src/mk.sh
@@ -43,8 +43,6 @@ function mk_build
     PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
   fi
 
-  PARALLEL_CORES=$(( $PARALLEL_CORES * 2 ))
-
   say "make -j$PARALLEL_CORES $MAKE_OPTS"
   make -j$PARALLEL_CORES $MAKE_OPTS
 }


### PR DESCRIPTION
Since 'nproc --all' and 'grep -c ^processor /proc/cpuinfo' return
the correct number of CPU's even if hype-threading is enable, it
is not necessary to multiply varible PARALLEL_CORES by 2.

Fixes #85

Signed-off-by: Rodrigo Ribeiro Carvalho <rodrigorsdc@gmail.com>