### PR TITLE
Double quote vars to prevent word splitting at km and setup.sh

### DIFF
--- a/kw
+++ b/kw
@@ -18,7 +18,7 @@ function kw()
   case "$action" in
     mount|mo)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_mount
         local ret=$?
@@ -28,7 +28,7 @@ function kw()
       ;;
     umount|um)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_umount
         local ret=$?
@@ -38,21 +38,21 @@ function kw()
       ;;
     boot|bo)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_boot
       )
       ;;
     up|u)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_up
       )
       ;;
     prepare|p)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_prepare
         local ret=$?
@@ -62,7 +62,7 @@ function kw()
       ;;
     build|b)
       (
-        . $src_script_path/mk.sh --source-only
+        . "$src_script_path"/mk.sh --source-only
 
         mk_build
         local ret=$?
@@ -72,7 +72,7 @@ function kw()
       ;;
     install|i)
       (
-        . $src_script_path/mk.sh --source-only
+        . "$src_script_path"/mk.sh --source-only
 
         mk_install
         local ret=$?
@@ -82,7 +82,7 @@ function kw()
       ;;
     new|n)
       (
-        . $src_script_path/mk.sh --source-only
+        . "$src_script_path"/mk.sh --source-only
 
         vm_new_release_deploy
         local ret=$?
@@ -92,7 +92,7 @@ function kw()
       ;;
     bi)
       (
-        . $src_script_path/mk.sh --source-only
+        . "$src_script_path"/mk.sh --source-only
 
         mk_build && mk_install
         local ret=$?
@@ -102,49 +102,49 @@ function kw()
       ;;
     ssh|s)
       (
-        . $src_script_path/vm.sh --source-only
+        . "$src_script_path"/vm.sh --source-only
 
         vm_ssh $@
       )
       ;;
     vars|v)
       (
-        . $src_script_path/commons.sh --source-only
+        . "$src_script_path"/commons.sh --source-only
 
         show_variables
       )
       ;;
     codestyle|c)
       (
-      . $src_script_path/checkpatch_wrapper.sh --source-only
+      . "$src_script_path"/checkpatch_wrapper.sh --source-only
 
         execute_checkpatch $@
       )
       ;;
     maintainers|m)
       (
-        . $src_script_path/get_maintainer_wrapper.sh --source-only
+        . "$src_script_path"/get_maintainer_wrapper.sh --source-only
 
         execute_get_maintainer $@
       )
       ;;
     configm|g)
       (
-        . $src_script_path/config_manager.sh --source-only
+        . "$src_script_path"/config_manager.sh --source-only
 
         execute_config_manager $@
       )
       ;;
     help|h)
       (
-        . $src_script_path/help.sh --source-only
+        . "$src_script_path"/help.sh --source-only
 
         kworkflow-help
       )
       ;;
     explore|e)
       (
-        . $src_script_path/explore.sh --source-only
+        . "$src_script_path"/explore.sh --source-only
 
         explore "$@"
       )
@@ -158,7 +158,7 @@ function kw()
       ;;
     *)
       (
-        . $src_script_path/help.sh --source-only
+        . "$src_script_path"/help.sh --source-only
 
         complain "Invalid option"
         kworkflow-help

--- a/setup.sh
+++ b/setup.sh
@@ -37,22 +37,22 @@ function clean_legacy()
   local toDelete="$APPLICATIONNAME"
   eval "sed -i '/$toDelete/d' $HOME/.bashrc"
   if [[ $completely_remove =~ "-d" ]]; then
-    mv $INSTALLTO $trash
+    mv "$INSTALLTO" "$trash"
     return 0
   fi
 
   # Remove files
-  if [ -d $INSTALLTO ]; then
+  if [ -d "$INSTALLTO" ]; then
     # If we have configs, we should keep it
-    if [ -d $INSTALLTO/$CONFIGS_PATH ]; then
-        for content in $INSTALLTO/*; do
+    if [ -d "$INSTALLTO/$CONFIGS_PATH" ]; then
+        for content in "$INSTALLTO"/*; do
           if [[ $content =~ "configs" ]]; then
             continue
           fi
-          mv $content $trash
+          mv "$content" "$trash"
         done
     else
-      mv $INSTALLTO $trash
+      mv "$INSTALLTO" "$trash"
     fi
   fi
 }
@@ -61,24 +61,24 @@ function setup_config_file()
 {
   say "Setting up global configuration file"
   local config_files="$INSTALLTO/$CONFIG_DIR/*.config"
-  sed -i "s/USERKW/$USER/g" $config_files
+  sed -i "s/USERKW/$USER/g" "$config_files"
   # FIXME: The following sed command assumes users won't
   # have files containing ",".
-  sed -i "s,INSTALLPATH,$INSTALLTO,g" $config_files
-  sed -i "/^#?.*/d" $config_files
+  sed -i "s,INSTALLPATH,$INSTALLTO,g" "$config_files"
+  sed -i "/^#?.*/d" "$config_files"
 
 }
 
 function synchronize_fish()
 {
-    local kw_fish_path='set -gx PATH $PATH:/home/lso/.config/kw'
+    local kw_fish_path="set -gx PATH $PATH:/home/lso/.config/kw"
 
     say "Fish detected. Setting up fish support."
-    mkdir -p $FISH_COMPLETION_PATH
-    rsync -vr $SRCDIR/kw.fish $FISH_COMPLETION_PATH/kw.fish
+    mkdir -p "$FISH_COMPLETION_PATH"
+    rsync -vr $SRCDIR/kw.fish "$FISH_COMPLETION_PATH"/kw.fish
 
-    if ! grep -F "$kw_fish_path" $FISH_CONFIG_PATH/config.fish; then
-       echo $kw_fish_path >> $FISH_CONFIG_PATH/config.fish
+    if ! grep -F "$kw_fish_path" "$FISH_CONFIG_PATH"/config.fish; then
+       echo "$kw_fish_path" >> "$FISH_CONFIG_PATH"/config.fish
     fi
 }
 
@@ -87,24 +87,24 @@ function synchronize_files()
 {
   say "Installing ..."
 
-  mkdir -p $INSTALLTO
+  mkdir -p "$INSTALLTO"
 
   # Copy the script
-  cp $APPLICATIONNAME $INSTALLTO
-  rsync -vr $SRCDIR $INSTALLTO
-  rsync -vr $DEPLOY_DIR $INSTALLTO
-  rsync -vr $SOUNDS $INSTALLTO
-  rsync -vr $DOCUMENTATION $INSTALLTO
+  cp $APPLICATIONNAME "$INSTALLTO"
+  rsync -vr $SRCDIR "$INSTALLTO"
+  rsync -vr $DEPLOY_DIR "$INSTALLTO"
+  rsync -vr $SOUNDS "$INSTALLTO"
+  rsync -vr $DOCUMENTATION "$INSTALLTO"
 
   # Configuration
-  rsync -vr $CONFIG_DIR $INSTALLTO
+  rsync -vr $CONFIG_DIR "$INSTALLTO"
   setup_config_file
 
   if [ -f "$HOME/.bashrc" ]; then
       # Add to bashrc
-      echo "# $APPLICATIONNAME" >> $HOME/.bashrc
-      echo "PATH=\$PATH:$INSTALLTO" >> $HOME/.bashrc
-      echo "source $INSTALLTO/$SRCDIR/$BASH_AUTOCOMPLETE.sh" >> $HOME/.bashrc
+      echo "# $APPLICATIONNAME" >> "$HOME/.bashrc"
+      echo "PATH=\$PATH:$INSTALLTO" >> "$HOME/.bashrc"
+      echo "source $INSTALLTO/$SRCDIR/$BASH_AUTOCOMPLETE.sh" >> "$HOME/.bashrc"
   else
       warning "Unable to find a shell."
   fi
@@ -113,12 +113,10 @@ function synchronize_files()
       synchronize_fish
   fi
 
-  say $SEPARATOR
+  say "$SEPARATOR"
   say "$APPLICATIONNAME installed into $INSTALLTO"
-  say $SEPARATOR
+  say "$SEPARATOR"
 }
-
-
 
 function install_home()
 {


### PR DESCRIPTION
Hello,

This PR add double quote vars to prevent word splitting in some files. The rationale behind this can be found here: https://github.com/koalaman/shellcheck/wiki/Sc2086, but is basically to avoid expand arguments with spaces, that can lead to break parameters and commands. Also, this PR is a little effort to add  `shellcheck` to the future CI for `kworkflow`. `shellcheck` is a tool that acts like `pylint` for Python, checking unused variables, bad coding practices/style and common errors.

Thanks!

