### PR TITLE
Improve setup's "user experience" and some cleanup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,6 @@
 set -e
 
 declare -r APPLICATIONNAME="kw"
-declare -r APPLICATIONNAME_1="vm"
-declare -r APPLICATIONNAME_2="mk"
 declare -r SRCDIR="src"
 declare -r DEPLOY_DIR="deploy_rules"
 declare -r CONFIG_DIR="etc"

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,15 @@ function usage()
   say "--html               Build $APPLICATIONNAME's documentation as HTML pages into ./build"
 }
 
+function confirm_complete_removal()
+{
+  warning "This operation will completely remove all files related to kw,"
+  warning "including the kernel '.config' files under its controls."
+  if [[ $(ask_yN "Do you want to proceed?") =~ "0" ]]; then
+    exit 0
+  fi
+}
+
 function clean_legacy()
 {
   say "Removing ..."
@@ -142,6 +151,7 @@ case $1 in
     # not want to add a short version, and the user has to be sure about this
     # operation.
   --completely-remove)
+    confirm_complete_removal
     clean_legacy "-d"
     ;;
   --help | -h)

--- a/setup.sh
+++ b/setup.sh
@@ -23,9 +23,14 @@ declare -r CONFIGS_PATH="configs"
 
 function usage()
 {
-  say "--install   | -i   Install $APPLICATIONNAME"
-  say "--uninstall | -u   Uninstall $APPLICATIONNAME"
-  say "--completely-remove Remove $APPLICATIONNAME and all files under its responsibility"
+  say "usage: ./setup.sh option"
+  say ""
+  say "Where option may be one of the following:"
+  say "--help      | -h     Display this usage message"
+  say "--install   | -i     Install $APPLICATIONNAME"
+  say "--uninstall | -u     Uninstall $APPLICATIONNAME"
+  say "--completely-remove  Remove $APPLICATIONNAME and all files under its responsibility"
+  say "--html               Build $APPLICATIONNAME's documentation as HTML pages into ./build"
 }
 
 function clean_legacy()
@@ -141,7 +146,7 @@ case $1 in
   --completely-remove)
     clean_legacy "-d"
     ;;
-  --help)
+  --help | -h)
     usage
     ;;
   --html)


### PR DESCRIPTION
This is a simple patchset. It contains three changes:

* Improvements to the --help message of setup.sh, including some missing options
* Cleanup of unused variables
* Addition of a user confirmation for --completely-remove