### PR TITLE
src: kwio: Make notification run in background

### DIFF
--- a/etc/kworkflow.config
+++ b/etc/kworkflow.config
@@ -36,10 +36,16 @@ qemu_path_image=/home/USERKW/p/virty.qcow2
 # on this options)
 alert=n
 
-# Command to run for sound completion alert
-sound_alert_command=paplay INSTALLPATH/sounds/complete.wav &
+# Command to run for sound completion alert (This command will be executed in
+# the background)
+sound_alert_command=paplay INSTALLPATH/sounds/complete.wav
 
-# Command to run for visual completion alert
+# Command to run for visual completion alert (This command will be executed in
+# the background)
 # Note: You may use $COMMAND, which will be replaced by the kw command
 #       whose conclusion the user wished to be alerted.
+# Note: The below command is an example that may work in many different
+#       distros, but we cannot guarantee it. For this reason, check if it works
+#       in your favorite OS or replaces it for your preferred notification
+#       tool.
 visual_alert_command=notify-send -i checkbox -t 10000 "kw" "Command: \\"$COMMAND\\" completed!"

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -28,9 +28,9 @@ function alert_completion()
 
   grep -o . <<< "$opts" | while read option;  do
     if [ "$option" == "v" ]; then
-      eval "${configurations[visual_alert_command]}"
+      eval "${configurations[visual_alert_command]} &"
     elif [ "$option" == "s" ]; then
-      eval "${configurations[sound_alert_command]}"
+      eval "${configurations[sound_alert_command]} &"
     fi
   done
 }


### PR DESCRIPTION
We noticed that the command `notify-send` behaves differently in Debian
and ArchLinux. After inspecting the code, we saw that kw does not put
the command in background; for this reason, this commit make kw put a
notification execution in background.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>