### PR TITLE
Add travis-ci support for kw

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: bash
+os: linux
+dist: xenial
+
+# Prepare for dependencies installation
+before_install:
+  - sudo apt-get -y update
+
+# Install dependencies
+install:
+  - >
+    sudo apt-get -y install libguestfs-tools qemu ansible bash git
+    python-docutils dash shunit2 fish python-sphinx
+
+# Prepare to execute tests
+before_script:
+  - ./run_tests.sh prepare
+
+# Execute tests, docs build and kw installation to check for errors
+script:
+  - ./run_tests.sh
+  - ./setup.sh --html
+  - ./setup.sh -i
+
+# Disable notifications by email for now are there're some issues to be solved
+# (#126 and #127) that still makes the tests fail at travis-ci (and we don't
+# want emails for them). TODO: remove this once the issues are solved.
+notifications:
+  email: false
+

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -43,7 +43,8 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.imgmath',
+    # Not needed for now, and it's not supported on older versions of Sphinx
+    #'sphinx.ext.imgmath',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
 ]

--- a/documentation/content/howtocontribute.rst
+++ b/documentation/content/howtocontribute.rst
@@ -43,9 +43,12 @@ development cycle.
    :align: center
 
 .. note::
-    One of our main goals it keeps kw stable, in this sense, **if you send a
-    new patch do not forget to add tests**. If you want to know more about
-    tests, take a look at `About Tests` page.
+    One of our main goals is to keep kw stable. In this sense, **if you send a
+    new patch do not forget to add tests**. You might also want to fork `kw at
+    github <https://github.com/rodrigosiqueira/kworkflow/>`_ and allow
+    `travis-ci <https://travis-ci.org/>`_ builds for it, to automatically run
+    the test in the cloud. If you want to know more about tests, take a look at
+    `About Tests` page.
 
 Commit Messages
 ---------------

--- a/documentation/content/tests.rst
+++ b/documentation/content/tests.rst
@@ -33,3 +33,8 @@ the external files, you can use::
 .. note::
    `run_tests.sh` script must be run from the directory it is in,
    i.e. the root of the repository. Otherwise, it may not execute properly.
+
+Kw is already prepared to run tests, build the documentation and check the
+installation in `travis-ci <https://travis-ci.org/>`_ . To have it continuously
+test your fork of kw on GitHub, upon pushes and pull requests, simply enable
+the travis-ci builds for it at https://travis-ci.org/account/repositories.


### PR DESCRIPTION
This will allow us to use the travis-ci infrastructure to test KW's pull requests and pushes. Note that there're still two issues (#126 and  #127) that currently make the travis-ci builds **fail**. But I think it's OK to add travis-ci support now and correct the issues latter.

Other modifications:
- The sphinx extension `sphinx.ext.imgmath` is not present on older versions of sphinx (as the one used by travis-ci). Since we also don't currently use it, let's remove this dependency.
- Add information on how to use travis-ci builds for kw at `documentation/content/tests.rst` and a brief memo for newcomers at `documentation/content/howtocontribute.rst`.

Note: @rodrigosiqueira as Kworkflow is hosted in your account, you will need to enable travis builds for it in travis-ci.org if you want the tests to be automatically executed on PRs and pushes.

Closes #72